### PR TITLE
Adding a mathematically accurate estimate for the time to fill a town

### DIFF
--- a/master/page/townHall.js
+++ b/master/page/townHall.js
@@ -20,7 +20,7 @@ zJS.Page.townHall = {
             if (happiness < freespace) {
                 time = '\u221E';
             } else {
-                time = (((50 / happiness) + (50 / last_happiness)) / 2 * freespace).toFixed(1);
+                time = (-50*Math.log((happiness-freespace)/happiness)).toFixed(1);
             }
             return time;
         }


### PR DESCRIPTION
Adding an improvement of the new code for estimating when a town will be full of citizens given the standard Ikariam population growth laws.

The exact mathematical formula for the time needed to fill an Ikariam town
with citizens is:
  -50 * ln( (happiness - freespace) / happiness )

The formula has been used in practice for months and has been proven to be accurate.
This commit applies the formula to the new IkaEasy code.
A new IkaEasy distribution that included the commit was created and tested.