### PR TITLE
Building popups: adding an estimate of when the needed resources will be ready

### DIFF
--- a/master/langs/bg.js
+++ b/master/langs/bg.js
@@ -26,7 +26,7 @@ langs.bg = {
     'per_week': "За седмица",
     'per_month': "За месец",
     'left': "Остава",
-    'hours': "часове",
+    'hours': "часа",
     'days': "дни",
     'months': "месеци",
     'years': "години",

--- a/master/page/__common.js
+++ b/master/page/__common.js
@@ -449,6 +449,22 @@ zJS.Page.__common = {
             })
         }
     },
+    getResourceProduction: function() {
+        console.log('getResourceProduction');
+        function getPageValue(valueId) {
+            return $('#' + valueId).text() == '-' ? 0 : $('#' + valueId).text().replace(/[^\d+]/g, '');
+        }
+
+        var production = {};
+        production.wood = getPageValue('js_GlobalMenu_resourceProduction');
+        console.log('wood: ' + ' : ' + production.wood);
+        production.wine = getPageValue('js_GlobalMenu_production_wine') - getPageValue('js_GlobalMenu_WineConsumption');
+        production.marble = getPageValue('js_GlobalMenu_production_marble');
+        production.crystal = getPageValue('js_GlobalMenu_production_crystal');
+        production.sulfur = getPageValue('js_GlobalMenu_production_sulfur');
+
+        return production;
+    },
     /*
      * Display resource spend per hour
      */

--- a/master/page/city.js
+++ b/master/page/city.js
@@ -255,7 +255,7 @@ zJS.Page.city = {
                         if(b_need < 0) {
                             sources_ok = false;
                             if (production[k] > 0) {
-                                timeNeeded =  '&nbsp;(' + zJS.Utils.hoursToTime(-b_need/production[k]) + '&nbsp' + zJS.Lang.hours + ')';
+                                timeNeeded =  '&nbsp;(' + zJS.Utils.hoursToTime(-b_need/production[k]) + '&nbsp;' + zJS.Lang.hours + ')';
                             }
                         }
 

--- a/master/page/city.js
+++ b/master/page/city.js
@@ -255,7 +255,7 @@ zJS.Page.city = {
                         if(b_need < 0) {
                             sources_ok = false;
                             if (production[k] > 0) {
-                                timeNeeded =  '&nbsp;(' + zJS.Utils.toTime(-b_need/production[k]) + ')';
+                                timeNeeded =  '&nbsp;(' + zJS.Utils.hoursToTime(-b_need/production[k]) + '&nbsp' + zJS.Lang.hours + ')';
                             }
                         }
 

--- a/master/page/city.js
+++ b/master/page/city.js
@@ -215,6 +215,7 @@ zJS.Page.city = {
 
         // Узнаем кол-во ресурсов в городе
         var sourceOnCity = zJS.Var.getCityResources();
+        var production = zJS.Page.__common.getResourceProduction();
 
         // Проверяем, нет ли строящихся зданий?
         var bb_icon = ($('#locations').find('.constructionSite').length > 0) ? 'build_blue' : 'build_green';
@@ -250,11 +251,15 @@ zJS.Page.city = {
                         var b_minus = Math.floor(v * this.__watcher_minus[k]);
                         var b_need = (sourceOnCity[k] - b_minus);
 
+                        var timeNeeded = '';
                         if(b_need < 0) {
                             sources_ok = false;
+                            if (production[k] > 0) {
+                                timeNeeded =  '&nbsp;(' + zJS.Utils.toTime(-b_need/production[k]) + ')';
+                            }
                         }
 
-                        var line = $('<div class="' + k + '"><div class="ikaeasy_tooltip_left"></div><div class="ikaeasy_tooltip_right"></div><div class="ikaeasy_tooltip_center">' + zJS.Utils.formatNumber(b_need) + '</div></div>');
+                        var line = $('<div class="' + k + '"><div class="ikaeasy_tooltip_left"></div><div class="ikaeasy_tooltip_right"></div><div class="ikaeasy_tooltip_center">' + zJS.Utils.formatNumber(b_need) + timeNeeded + '</div></div>');
 
                         if(b_need < 0) {
                             $(line).addClass('ikaeasy_red');

--- a/master/page/townHall.js
+++ b/master/page/townHall.js
@@ -14,16 +14,13 @@ if(typeof zJS.Page == "undefined") {
 zJS.Page.townHall = {
     init: function() {
         var inhabitants = [10, 50, 100, 250, 500];
-        function toTime(dhours) {
-            return dhours.toFixed(0) + ':' + ('0' + ((dhours % 1)*60).toFixed(0)).slice(-2);
-        }
         function result_time(happiness, freespace) {
             var time; //time is in minutes
             var last_happiness = happiness - freespace + 1; //happines when last inhabitant is beeing created
             if (happiness < freespace) {
                 time = '\u221E';
             } else {
-                time = toTime(-50*Math.log((happiness-freespace)/happiness));
+                time = zJS.Utils.hoursToTime(-50*Math.log((happiness-freespace)/happiness));
             }
             return time;
         }

--- a/master/page/townHall.js
+++ b/master/page/townHall.js
@@ -14,13 +14,16 @@ if(typeof zJS.Page == "undefined") {
 zJS.Page.townHall = {
     init: function() {
         var inhabitants = [10, 50, 100, 250, 500];
+        function toTime(dhours) {
+            return dhours.toFixed(0) + ':' + ('0' + ((dhours % 1)*60).toFixed(0)).slice(-2);
+        }
         function result_time(happiness, freespace) {
             var time; //time is in minutes
             var last_happiness = happiness - freespace + 1; //happines when last inhabitant is beeing created
             if (happiness < freespace) {
                 time = '\u221E';
             } else {
-                time = (-50*Math.log((happiness-freespace)/happiness)).toFixed(1);
+                time = toTime(-50*Math.log((happiness-freespace)/happiness));
             }
             return time;
         }

--- a/master/zJS/utils.js
+++ b/master/zJS/utils.js
@@ -320,7 +320,7 @@ zJS.Utils = {
         $('#__ikaeasy')[0].dispatchEvent(customEvent);
     },
     hoursToTime: function(dhours) {
-        return dhours.toFixed(0) + ':' + ('0' + ((dhours % 1)*60).toFixed(0)).slice(-2);
+        return Math.floor(dhours) + ':' + ('0' + ((dhours % 1)*60).toFixed(0)).slice(-2);
     },
     transformHours: function(hours) {
         if(hours < 24)

--- a/master/zJS/utils.js
+++ b/master/zJS/utils.js
@@ -319,6 +319,9 @@ zJS.Utils = {
         customEvent.initEvent('execute_js', true, true);
         $('#__ikaeasy')[0].dispatchEvent(customEvent);
     },
+    toTime: function(dhours) {
+        return dhours.toFixed(0) + ':' + ('0' + ((dhours % 1)*60).toFixed(0)).slice(-2);
+    },
     transformHours: function(hours) {
         if(hours < 24)
             return Math.round(hours) + ' ' + zJS.Lang.hours;

--- a/master/zJS/utils.js
+++ b/master/zJS/utils.js
@@ -319,7 +319,7 @@ zJS.Utils = {
         customEvent.initEvent('execute_js', true, true);
         $('#__ikaeasy')[0].dispatchEvent(customEvent);
     },
-    toTime: function(dhours) {
+    hoursToTime: function(dhours) {
         return dhours.toFixed(0) + ':' + ('0' + ((dhours % 1)*60).toFixed(0)).slice(-2);
     },
     transformHours: function(hours) {


### PR DESCRIPTION
Augmenting the building popups by adding an estimate how long it would take
to produce the missing resources for an upgrade.

Also adding a method to present the remaining time using the hh:mm format
(for example 6:30 and 11:13 hours, rather than 6.5 or 11.2 hours)

![screenshot](https://cloud.githubusercontent.com/assets/24373275/20895014/6449db30-bb20-11e6-9a47-1dd077254b4a.png)
