### PR TITLE
Fixing the pirate point conversion dialog

### DIFF
--- a/master/css/ikaeasy.css
+++ b/master/css/ikaeasy.css
@@ -256,15 +256,15 @@
     max-width: 242px;
 }
 
-#container #leftMenu .city_menu .expandable .image_transporter {
+#container #leftMenu .city_menu .image_transporter {
     background: url(../images/transporter.png) no-repeat 0 0;
 }
 
-#container #leftMenu .city_menu .expandable .image_embassy {
+#container #leftMenu .city_menu .image_embassy {
     background: url(../images/embassy.png) no-repeat 0 0;
 }
 
-#container #leftMenu .city_menu .expandable .image_chat {
+#container #leftMenu .city_menu .image_chat {
     background: url(../images/ally_message.png) no-repeat 0 0;
 }
 

--- a/master/zJS/utils.js
+++ b/master/zJS/utils.js
@@ -274,7 +274,7 @@ zJS.Utils = {
         var menu_slot = $js_viewCityMenu.find('.menu_slots');
 
         var _slot = $('li', menu_slot).length;
-        var li = $('<li class="expandable slot' + _slot + '" style="width: 53px; "><div class="image ' + image + '"></div><div class="name"><span class="namebox">' + title + '</span></div></li>');
+        var li = $('<li class="slot' + _slot + '" style="width: 53px; "><div class="image ' + image + '"></div><div class="name"><span class="namebox">' + title + '</span></div></li>');
         $(menu_slot).prepend(li);
 
         var animate = false;


### PR DESCRIPTION
Currently the slider in the pirate point conversion dialog does not work when IkaEasy is enabled.
It appears that the issue occurs when an item with the class 'expandable' is added to the left menu.
For the time being the 'expandable' class is removed from the additional left menu items that we are adding.
There is no real difference in functionality as a result, but the pirate point conversion dialog now works.